### PR TITLE
Fix in ZipOutputStreamFixture and improvement on ZipInputStream to use VirtualStream instead of FileStream as ReadOnlySeekableStream's underlying Stream.

### DIFF
--- a/src/Be.Stateless.BizTalk.Stream.Tests/Stream/ZipOutputStreamFixture.cs
+++ b/src/Be.Stateless.BizTalk.Stream.Tests/Stream/ZipOutputStreamFixture.cs
@@ -36,7 +36,7 @@ namespace Be.Stateless.BizTalk.Stream
 			using (var clearStream = TextStreamDummy.Create(1024 * 64))
 			using (var compressedStream = new ZipOutputStream(clearStream, "entry-name"))
 			{
-				compressedStream.IsZipValid().Should().BeTrue();
+				compressedStream.IsValidZipArchive().Should().BeTrue();
 			}
 		}
 

--- a/src/Be.Stateless.BizTalk.Stream.Unit/Unit/Stream/Extensions/StreamExtensions.cs
+++ b/src/Be.Stateless.BizTalk.Stream.Unit/Unit/Stream/Extensions/StreamExtensions.cs
@@ -21,8 +21,6 @@ using System.IO;
 using System.IO.Compression;
 using System.Xml;
 using Be.Stateless.BizTalk.Stream;
-using Microsoft.BizTalk.Streaming;
-using XmlTranslatorStream = Be.Stateless.BizTalk.Stream.XmlTranslatorStream;
 
 namespace Be.Stateless.BizTalk.Unit.Stream.Extensions
 {

--- a/src/Be.Stateless.BizTalk.Stream/Stream/ReadOnlySeekableStream.cs
+++ b/src/Be.Stateless.BizTalk.Stream/Stream/ReadOnlySeekableStream.cs
@@ -26,13 +26,13 @@ namespace Be.Stateless.BizTalk.Stream
 	/// purpose of this Stream is to implement an often used pattern which is to use the <see
 	/// cref="Microsoft.BizTalk.Streaming.ReadOnlySeekableStream"/> in conjunction with a <see cref="VirtualStream"/>. The
 	/// pattern being that VirtualStream will hold the stream data in memory until a threshold is reached after which it will
-   /// switch to disk. The benefit being that it avoids using unnecessary IO resources for small messages. Note that there is a
+	/// switch to disk. The benefit being that it avoids using unnecessary IO resources for small messages. Note that there is a
 	/// small performance hit once the stream changes persistence mode.</para> <para>The developer can alternatively choose to
 	/// directly use the <see cref="Microsoft.BizTalk.Streaming.ReadOnlySeekableStream"/> which exposes constructor forcing the
 	/// stream to always store the data into a File on disk.</para> <para>Note that the temporary file is created in the AppData
 	/// directory of the user running the process i.e. C:\Users\{User}\AppData\Local\Temp. For example, if the process is a
 	/// BizTalk Host Instance, the temporary file will be created in the AppData folder of the Service Account under which it is
-   /// running. The temporary file name is prefixed with the string "VST".</para>
+	/// running. The temporary file name is prefixed with the string "VST".</para>
 	/// </summary>
 	public class ReadOnlySeekableStream : Microsoft.BizTalk.Streaming.ReadOnlySeekableStream
 	{

--- a/src/Be.Stateless.BizTalk.Stream/Stream/ReadOnlySeekableStream.cs
+++ b/src/Be.Stateless.BizTalk.Stream/Stream/ReadOnlySeekableStream.cs
@@ -16,36 +16,53 @@
 
 #endregion
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.BizTalk.Streaming;
 
 namespace Be.Stateless.BizTalk.Stream
 {
 	/// <summary>
-	/// This stream wraps an underlying stream into a read-only seekable stream. It does so by re-using BizTalk's <see
-	/// cref="Microsoft.BizTalk.Streaming.ReadOnlySeekableStream"/> as-is without additional functionality. <para>The sole
-	/// purpose of this Stream is to implement an often used pattern which is to use the <see
-	/// cref="Microsoft.BizTalk.Streaming.ReadOnlySeekableStream"/> in conjunction with a <see cref="VirtualStream"/>. The
-	/// pattern being that VirtualStream will hold the stream data in memory until a threshold is reached after which it will
-	/// switch to disk. The benefit being that it avoids using unnecessary IO resources for small messages. Note that there is a
-	/// small performance hit once the stream changes persistence mode.</para> <para>The developer can alternatively choose to
-	/// directly use the <see cref="Microsoft.BizTalk.Streaming.ReadOnlySeekableStream"/> which exposes constructor forcing the
-	/// stream to always store the data into a File on disk.</para> <para>Note that the temporary file is created in the AppData
-	/// directory of the user running the process i.e. C:\Users\{User}\AppData\Local\Temp. For example, if the process is a
-	/// BizTalk Host Instance, the temporary file will be created in the AppData folder of the Service Account under which it is
-	/// running. The temporary file name is prefixed with the string "VST".</para>
+	/// This stream wraps an underlying stream into a read-only seekable stream. It does so by reusing BizTalk's <see
+	/// cref="Microsoft.BizTalk.Streaming.ReadOnlySeekableStream">Microsoft.BizTalk.Streaming.ReadOnlySeekableStream</see> with
+	/// a <see cref="VirtualStream"/>.
 	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The sole purpose of this Stream is to implement an often used pattern which is to use the <see
+	/// cref="Microsoft.BizTalk.Streaming.ReadOnlySeekableStream">Microsoft.BizTalk.Streaming.ReadOnlySeekableStream</see> in
+	/// conjunction with a <see cref="VirtualStream"/>. The pattern being that <see cref="VirtualStream"/> will hold the stream
+	/// data in memory until a threshold is reached after which it will switch to disk. The benefit being that it avoids using
+	/// unnecessary IO resources for small messages. Note that there is a small performance hit once the stream changes
+	/// persistence mode.
+	/// </para>
+	/// <para>
+	/// The developer can alternatively choose to directly use the <see
+	/// cref="Microsoft.BizTalk.Streaming.ReadOnlySeekableStream">Microsoft.BizTalk.Streaming.ReadOnlySeekableStream</see> which
+	/// exposes constructor forcing the stream to always store the data into a File on disk.
+	/// </para>
+	/// <para>
+	/// Note that the temporary file is created in the AppData directory of the user running the process i.e.
+	/// C:\Users\{User}\AppData\Local\Temp. For example, if the process is a BizTalk Host Instance, the temporary file will be
+	/// created in the AppData folder of the Service Account under which it is running. The temporary file name is prefixed with
+	/// the string "VST".
+	/// </para>
+	/// </remarks>
 	public class ReadOnlySeekableStream : Microsoft.BizTalk.Streaming.ReadOnlySeekableStream
 	{
 		/// <summary>
 		/// Constructor.
 		/// </summary>
-		/// <param name="source">The underlying stream.</param>
-		/// <param name="bufferSize">Buffer size in bytes used by <see cref="Microsoft.BizTalk.Streaming.ReadOnlySeekableStream"/> and <see cref="VirtualStream"/>.</param>
-		/// <param name="thresholdSize">Size in bytes after which <see cref="VirtualStream"/> will switch from a MemoryStream to a FileStream.</param>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage(
-			"Reliability",
-			"CA2000:Dispose objects before losing scope",
-			Justification = "The base class Dispose() method calls Close() on the VirtualStream")]
+		/// <param name="source">
+		/// The underlying stream.
+		/// </param>
+		/// <param name="bufferSize">
+		/// Buffer size in bytes used by <see cref="Microsoft.BizTalk.Streaming.ReadOnlySeekableStream"/> and <see
+		/// cref="VirtualStream"/>.
+		/// </param>
+		/// <param name="thresholdSize">
+		/// Size in bytes after which <see cref="VirtualStream"/> will switch from a MemoryStream to a FileStream.
+		/// </param>
+		[SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The base class Dispose() method calls Close() on the VirtualStream")]
 		public ReadOnlySeekableStream(System.IO.Stream source, int bufferSize = 8 * 1024, int thresholdSize = 1024 * 1024) : base(
 			source,
 			new VirtualStream(bufferSize, thresholdSize),

--- a/src/Be.Stateless.BizTalk.Stream/Stream/ReadOnlySeekableStream.cs
+++ b/src/Be.Stateless.BizTalk.Stream/Stream/ReadOnlySeekableStream.cs
@@ -1,0 +1,54 @@
+﻿#region Copyright & License
+
+// Copyright © 2012 - 2020 François Chabot
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using Microsoft.BizTalk.Streaming;
+
+namespace Be.Stateless.BizTalk.Stream
+{
+	/// <summary>
+	/// This stream wraps an underlying stream into a read-only seekable stream. It does so by re-using BizTalk's <see
+	/// cref="Microsoft.BizTalk.Streaming.ReadOnlySeekableStream"/> as-is without additional functionality. <para>The sole
+	/// purpose of this Stream is to implement an often used pattern which is to use the <see
+	/// cref="Microsoft.BizTalk.Streaming.ReadOnlySeekableStream"/> in conjunction with a <see cref="VirtualStream"/>. The
+	/// pattern being that VirtualStream will hold the stream data in memory until a threshold is reached after which it will
+   /// switch to disk. The benefit being that it avoids using unnecessary IO resources for small messages. Note that there is a
+	/// small performance hit once the stream changes persistence mode.</para> <para>The developer can alternatively choose to
+	/// directly use the <see cref="Microsoft.BizTalk.Streaming.ReadOnlySeekableStream"/> which exposes constructor forcing the
+	/// stream to always store the data into a File on disk.</para> <para>Note that the temporary file is created in the AppData
+	/// directory of the user running the process i.e. C:\Users\{User}\AppData\Local\Temp. For example, if the process is a
+	/// BizTalk Host Instance, the temporary file will be created in the AppData folder of the Service Account under which it is
+   /// running. The temporary file name is prefixed with the string "VST".</para>
+	/// </summary>
+	public class ReadOnlySeekableStream : Microsoft.BizTalk.Streaming.ReadOnlySeekableStream
+	{
+		/// <summary>
+		/// Constructor.
+		/// </summary>
+		/// <param name="source">The underlying stream.</param>
+		/// <param name="bufferSize">Buffer size in bytes used by <see cref="Microsoft.BizTalk.Streaming.ReadOnlySeekableStream"/> and <see cref="VirtualStream"/>.</param>
+		/// <param name="thresholdSize">Size in bytes after which <see cref="VirtualStream"/> will switch from a MemoryStream to a FileStream.</param>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage(
+			"Reliability",
+			"CA2000:Dispose objects before losing scope",
+			Justification = "The base class Dispose() method calls Close() on the VirtualStream")]
+		public ReadOnlySeekableStream(System.IO.Stream source, int bufferSize = 8 * 1024, int thresholdSize = 1024 * 1024) : base(
+			source,
+			new VirtualStream(bufferSize, thresholdSize),
+			bufferSize) { }
+	}
+}

--- a/src/Be.Stateless.BizTalk.Stream/Stream/ZipInputStream.cs
+++ b/src/Be.Stateless.BizTalk.Stream/Stream/ZipInputStream.cs
@@ -42,10 +42,7 @@ namespace Be.Stateless.BizTalk.Stream
 		public ZipInputStream(System.IO.Stream streamToDecompress)
 		{
 			if (streamToDecompress == null) throw new ArgumentNullException(nameof(streamToDecompress));
-			if (!streamToDecompress.CanSeek)
-			{
-				streamToDecompress = new ReadOnlySeekableStream(streamToDecompress);
-			}
+			if (!streamToDecompress.CanSeek) streamToDecompress = new ReadOnlySeekableStream(streamToDecompress);
 			_baseInputStream = streamToDecompress;
 		}
 

--- a/src/Be.Stateless.BizTalk.Stream/Stream/ZipInputStream.cs
+++ b/src/Be.Stateless.BizTalk.Stream/Stream/ZipInputStream.cs
@@ -43,7 +43,11 @@ namespace Be.Stateless.BizTalk.Stream
 		public ZipInputStream(System.IO.Stream streamToDecompress)
 		{
 			if (streamToDecompress == null) throw new ArgumentNullException(nameof(streamToDecompress));
-			if (!streamToDecompress.CanSeek) streamToDecompress = new ReadOnlySeekableStream(streamToDecompress);
+			if (!streamToDecompress.CanSeek)
+			{
+				var virtualStream = new VirtualStream(8*1024, 1024*1024);
+				streamToDecompress = new ReadOnlySeekableStream(streamToDecompress, virtualStream, 8*1024);
+			}
 			_baseInputStream = streamToDecompress;
 		}
 

--- a/src/Be.Stateless.BizTalk.Stream/Stream/ZipInputStream.cs
+++ b/src/Be.Stateless.BizTalk.Stream/Stream/ZipInputStream.cs
@@ -20,7 +20,6 @@ using System;
 using System.IO;
 using System.IO.Compression;
 using Be.Stateless.IO.Extensions;
-using Microsoft.BizTalk.Streaming;
 
 namespace Be.Stateless.BizTalk.Stream
 {
@@ -32,9 +31,9 @@ namespace Be.Stateless.BizTalk.Stream
 	/// <see cref="ZipInputStream"/> relies on <see cref="ZipArchive"/> for the decompression of the zip-stream. The stream
 	/// containing the zipped data must have exactly one <see cref="ZipArchiveEntry"/>. If more than one entry exist, only the
 	/// first one is decompressed and the remaining entries are disregarded. If the underlying stream given to the constructor
-	/// is not seekable, <see cref="ZipInputStream"/> will leverage BizTalk's built-in <see cref="ReadOnlySeekableStream"/> and
-	/// <see cref="VirtualStream"/> to avoid loading the whole stream in memory. This is necessary as <see cref="ZipArchive"/>
-	/// loads the entire archive stream in memory if the underlying stream does not support seeking.
+	/// is not seekable, <see cref="ZipInputStream"/> will leverage <see cref="ReadOnlySeekableStream"/> to avoid loading the
+	/// whole stream in memory. This is necessary as <see cref="ZipArchive"/> loads the entire archive stream in memory if the
+	/// underlying stream does not support seeking.
 	/// </remarks>
 	/// <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.io.compression.ziparchive">ZipArchive</seealso>
 	/// <seealso href="https://docs.microsoft.com/en-us/dotnet/api/system.io.compression.ziparchivemode#remarks">ZipArchiveMode</seealso>
@@ -45,8 +44,7 @@ namespace Be.Stateless.BizTalk.Stream
 			if (streamToDecompress == null) throw new ArgumentNullException(nameof(streamToDecompress));
 			if (!streamToDecompress.CanSeek)
 			{
-				var virtualStream = new VirtualStream(8*1024, 1024*1024);
-				streamToDecompress = new ReadOnlySeekableStream(streamToDecompress, virtualStream, 8*1024);
+				streamToDecompress = new ReadOnlySeekableStream(streamToDecompress);
 			}
 			_baseInputStream = streamToDecompress;
 		}


### PR DESCRIPTION
Hello Francois,
This pull request for 2 issues I found:
- A fix for a test in ZipOutputStreamFixture. This fixture was not compiling anymore, I think that's because you renamed the IsZipValid() extension method to IsValidZipArchive().
- ZipInputStream was using the ReadOnlySeekableStream(Stream source) constructor which itself uses a FileStream as underlying stream. I now use another constructor of ReadOnlySeekableStream so that I can pass a VirtualStream configured with 1Mb as threshold value. This way, VirtualStream is used as underlying stream and will keep the message in memory for messages under 1Mb and switch to a FileStream once the threshold is crossed. The benefit of this approach is that it avoids using unnecessary disk space and IO resources for small messages.